### PR TITLE
Parametrize operand images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,12 +49,19 @@ init_image() {
   METADATA_IMAGE_LATEST="$METADATA_IMAGE_NAME:latest$DASH_VERSION_RELEASE"
 
   # Registry
-  REGISTRY_IMAGE_MEM="docker.io/apicurio/apicurio-registry-mem:1.2.3.Final"
-  REGISTRY_IMAGE_KAFKA="docker.io/apicurio/apicurio-registry-kafka:1.2.3.Final"
-  REGISTRY_IMAGE_STREAMS="docker.io/apicurio/apicurio-registry-streams:1.2.3.Final"
-  REGISTRY_IMAGE_JPA="docker.io/apicurio/apicurio-registry-jpa:1.2.3.Final"
-  REGISTRY_IMAGE_INFINISPAN="docker.io/apicurio/apicurio-registry-infinispan:1.2.3.Final"
-
+  if [[ -n "$REPLACE_OPERANDS" ]]; then
+    REGISTRY_IMAGE_MEM="$OPERATOR_IMAGE_REPOSITORY/apicurio-registry-mem:latest$DASH_VERSION_RELEASE"
+    REGISTRY_IMAGE_KAFKA="$OPERATOR_IMAGE_REPOSITORY/apicurio-registry-kafka:latest$DASH_VERSION_RELEASE"
+    REGISTRY_IMAGE_STREAMS="$OPERATOR_IMAGE_REPOSITORY/apicurio-registry-streams:latest$DASH_VERSION_RELEASE"
+    REGISTRY_IMAGE_JPA="$OPERATOR_IMAGE_REPOSITORY/apicurio-registry-jpa:latest$DASH_VERSION_RELEASE"
+    REGISTRY_IMAGE_INFINISPAN="$OPERATOR_IMAGE_REPOSITORY/apicurio-registry-infinispan:latest$DASH_VERSION_RELEASE"
+  else
+    REGISTRY_IMAGE_MEM="docker.io/apicurio/apicurio-registry-mem:1.2.3.Final"
+    REGISTRY_IMAGE_KAFKA="docker.io/apicurio/apicurio-registry-kafka:1.2.3.Final"
+    REGISTRY_IMAGE_STREAMS="docker.io/apicurio/apicurio-registry-streams:1.2.3.Final"
+    REGISTRY_IMAGE_JPA="docker.io/apicurio/apicurio-registry-jpa:1.2.3.Final"
+    REGISTRY_IMAGE_INFINISPAN="docker.io/apicurio/apicurio-registry-infinispan:1.2.3.Final"
+  fi
 }
 
 replace() {
@@ -125,6 +132,11 @@ build() {
 
   compile_qs_yaml
   #unreplace
+}
+
+kubefiles() {
+  replace
+  compile_qs_yaml
 }
 
 minikube_deploy_cr() {
@@ -226,6 +238,10 @@ while [[ "$#" -gt 0 ]]; do
     PUSH_LATEST="true"
     shift
     ;;
+  --operands)
+    REPLACE_OPERANDS="true"
+    shift
+    ;;
   *)
     echo -e "Unknown parameter: '$1'.\n"
     help
@@ -240,6 +256,7 @@ fi
 
 case "$TARGET" in
 build) build ;;
+kubefiles) kubefiles ;;
 mkdeploy) minikube_deploy ;;
 mkundeploy) minikube_undeploy ;;
 push) push ;;

--- a/build.sh
+++ b/build.sh
@@ -48,15 +48,33 @@ init_image() {
   METADATA_IMAGE="$METADATA_IMAGE_NAME:$VERSION"
   METADATA_IMAGE_LATEST="$METADATA_IMAGE_NAME:latest$DASH_VERSION_RELEASE"
 
+  # Registry
+  REGISTRY_IMAGE_MEM="docker.io/apicurio/apicurio-registry-mem:1.2.3.Final"
+  REGISTRY_IMAGE_KAFKA="docker.io/apicurio/apicurio-registry-kafka:1.2.3.Final"
+  REGISTRY_IMAGE_STREAMS="docker.io/apicurio/apicurio-registry-streams:1.2.3.Final"
+  REGISTRY_IMAGE_JPA="docker.io/apicurio/apicurio-registry-jpa:1.2.3.Final"
+  REGISTRY_IMAGE_INFINISPAN="docker.io/apicurio/apicurio-registry-infinispan:1.2.3.Final"
+
 }
 
 replace() {
   init_image
   sed -i "s|{OPERATOR_IMAGE}|$OPERATOR_IMAGE # replaced {OPERATOR_IMAGE}|g" ./deploy/operator.yaml
+  sed -i "s|{REGISTRY_IMAGE_MEM}|$REGISTRY_IMAGE_MEM # replaced {REGISTRY_IMAGE_MEM}|g" ./deploy/operator.yaml
+  sed -i "s|{REGISTRY_IMAGE_KAFKA}|$REGISTRY_IMAGE_KAFKA # replaced {REGISTRY_IMAGE_KAFKA}|g" ./deploy/operator.yaml
+  sed -i "s|{REGISTRY_IMAGE_STREAMS}|$REGISTRY_IMAGE_STREAMS # replaced {REGISTRY_IMAGE_STREAMS}|g" ./deploy/operator.yaml
+  sed -i "s|{REGISTRY_IMAGE_JPA}|$REGISTRY_IMAGE_JPA # replaced {REGISTRY_IMAGE_JPA}|g" ./deploy/operator.yaml
+  sed -i "s|{REGISTRY_IMAGE_INFINISPAN}|$REGISTRY_IMAGE_INFINISPAN # replaced {REGISTRY_IMAGE_INFINISPAN}|g" ./deploy/operator.yaml
+
 }
 
 unreplace() {
   sed -i "s|$OPERATOR_IMAGE # replaced {OPERATOR_IMAGE}|{OPERATOR_IMAGE}|g" ./deploy/operator.yaml
+  sed -i "s|$REGISTRY_IMAGE_MEM # replaced {REGISTRY_IMAGE_MEM}|{REGISTRY_IMAGE_MEM}|g" ./deploy/operator.yaml
+  sed -i "s|$REGISTRY_IMAGE_KAFKA # replaced {REGISTRY_IMAGE_KAFKA}|{REGISTRY_IMAGE_KAFKA}|g" ./deploy/operator.yaml
+  sed -i "s|$REGISTRY_IMAGE_STREAMS # replaced {REGISTRY_IMAGE_STREAMS}|{REGISTRY_IMAGE_STREAMS}|g" ./deploy/operator.yaml
+  sed -i "s|$REGISTRY_IMAGE_JPA # replaced {REGISTRY_IMAGE_JPA}|{REGISTRY_IMAGE_JPA}|g" ./deploy/operator.yaml
+  sed -i "s|$REGISTRY_IMAGE_INFINISPAN # replaced {REGISTRY_IMAGE_INFINISPAN}|{REGISTRY_IMAGE_INFINISPAN}|g" ./deploy/operator.yaml
 }
 
 gen_csv() {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -27,15 +27,15 @@ spec:
               cpu: "2m"
           env:
             - name:  REGISTRY_IMAGE_MEM
-              value: "docker.io/apicurio/apicurio-registry-mem:1.2.3.Final"
+              value: {REGISTRY_IMAGE_MEM}
             - name:  REGISTRY_IMAGE_KAFKA
-              value: "docker.io/apicurio/apicurio-registry-kafka:1.2.3.Final"
+              value: {REGISTRY_IMAGE_KAFKA}
             - name:  REGISTRY_IMAGE_STREAMS
-              value: "docker.io/apicurio/apicurio-registry-streams:1.2.3.Final"
+              value: {REGISTRY_IMAGE_STREAMS}
             - name:  REGISTRY_IMAGE_JPA
-              value: "docker.io/apicurio/apicurio-registry-jpa:1.2.3.Final"
+              value: {REGISTRY_IMAGE_JPA}
             - name:  REGISTRY_IMAGE_INFINISPAN
-              value: "docker.io/apicurio/apicurio-registry-infinispan:1.2.3.Final"
+              value: {REGISTRY_IMAGE_INFINISPAN}
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
this PR moves the values of the different Apicurio Registry images to the build script, so they are replaced in the operator yaml when the operator image is replaced...

I need this change so registry images can be easily changed in release testing. 