### PR TITLE
Fix for "@" in SCRAM-SHA password

### DIFF
--- a/pkg/controller/apicurioregistry/cf_streams_security_scram.go
+++ b/pkg/controller/apicurioregistry/cf_streams_security_scram.go
@@ -161,8 +161,8 @@ func (this *StreamsSecurityScramCF) AddEnv(truststoreSecretName string, truststo
 
 	this.ctx.GetEnvCache().Set(NewSimpleEnvCacheEntry(ENV_REGISTRY_STREAMS_TOPOLOGY_SASL_MECHANISM, scramMechanism))
 
-	jaasConfig := "org.apache.kafka.common.security.scram.ScramLoginModule required username=$(" + ENV_REGISTRY_STREAMS_SCRAM_USER +
-		") password=$(" + ENV_REGISTRY_STREAMS_SCRAM_PASSWORD + ");"
+	jaasConfig := "org.apache.kafka.common.security.scram.ScramLoginModule required username='$(" + ENV_REGISTRY_STREAMS_SCRAM_USER +
+		")' password='$(" + ENV_REGISTRY_STREAMS_SCRAM_PASSWORD + ")';"
 
 	jaasconfigEntry := NewSimpleEnvCacheEntry(ENV_REGISTRY_STREAMS_TOPOLOGY_SASL_JAAS_CONFIG, jaasConfig)
 	jaasconfigEntry.SetInterpolationDependency(ENV_REGISTRY_STREAMS_SCRAM_USER)

--- a/pkg/controller/apicurioregistry/cf_streams_security_scram_ocp.go
+++ b/pkg/controller/apicurioregistry/cf_streams_security_scram_ocp.go
@@ -150,8 +150,8 @@ func (this *StreamsSecurityScramOcpCF) AddEnv(truststoreSecretName string, trust
 
 	this.ctx.GetEnvCache().Set(NewSimpleEnvCacheEntry(ENV_REGISTRY_STREAMS_TOPOLOGY_SASL_MECHANISM, scramMechanism))
 
-	jaasConfig := "org.apache.kafka.common.security.scram.ScramLoginModule required username=$(" + ENV_REGISTRY_STREAMS_SCRAM_USER +
-		") password=$(" + ENV_REGISTRY_STREAMS_SCRAM_PASSWORD + ");"
+	jaasConfig := "org.apache.kafka.common.security.scram.ScramLoginModule required username='$(" + ENV_REGISTRY_STREAMS_SCRAM_USER +
+		")' password='$(" + ENV_REGISTRY_STREAMS_SCRAM_PASSWORD + ")';"
 
 	jaasconfigEntry := NewSimpleEnvCacheEntry(ENV_REGISTRY_STREAMS_TOPOLOGY_SASL_JAAS_CONFIG, jaasConfig)
 	jaasconfigEntry.SetInterpolationDependency(ENV_REGISTRY_STREAMS_SCRAM_USER)


### PR DESCRIPTION
Surround username and password with single quotes to fix parse errors in kafka jaas config.  Fixes https://issues.redhat.com/browse/IPT-177