### PR TITLE
use correct images in kubernetes tests

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Test
         id: test
-        run: ./.github/scripts/test_operator.sh
+        run: CI_BUILD=true OPERATOR_IMAGE="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/apicurio-registry-operator:latest-dev" ./.github/scripts/test_operator.sh
 
       - name: Collect logs
         if: failure()


### PR DESCRIPTION
Currently the kubernetes tests run in every PR are not testing the actual image that has been built from the source included in the PR, this has been addressed in this PR and in [this other one](https://github.com/Apicurio/apicurio-registry-k8s-tests-e2e/pull/7) in e2e testsuite repo