### PR TITLE
fix: Update operator framework SDK to 0.18.2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 
 * Docker
 * https://github.com/golang/go[go] (1.13+, with `export GO111MODULE='on'`), and `$GOPATH` and `$GOROOT` set.
-* https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[Operator SDK] v11+
+* https://v0-18-x.sdk.operatorframework.io/docs/install-operator-sdk/[Operator SDK] v0.18.x
 * A running Kubernetes, https://kubernetes.io/docs/tasks/tools/install-minikube/[Minikube], OpenShift, or Minishift deployment with system admin access.
 
 [#quickstart]

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,16 @@ module github.com/Apicurio/apicurio-registry-operator
 go 1.13
 
 require (
-	github.com/Masterminds/semver v1.5.0
-	github.com/coreos/prometheus-operator v0.38.0
+	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/go-logr/logr v0.1.0
 	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/operator-framework/operator-sdk v0.17.0
+	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/spf13/pflag v1.0.5
-	k8s.io/api v0.17.4
-	k8s.io/apimachinery v0.17.4
+	k8s.io/api v0.18.2
+	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible
-	sigs.k8s.io/controller-runtime v0.5.2
+	sigs.k8s.io/controller-runtime v0.6.0
 )
 
 replace (


### PR DESCRIPTION
Previous versions depended indirectly on unsafe
and unlicensed code.

Contributes to: #101

Signed-off-by: Kit Davies <kit.davies@uk.ibm.com>