### PR TITLE
olm - test CI builds

### DIFF
--- a/.github/scripts/test_operator.sh
+++ b/.github/scripts/test_operator.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e -a
 
-OPERATOR_METADATA_IMAGE=docker.io/apicurio/apicurio-registry-operator-metadata:latest-dev
+VERSION=$(sed -n 's/^.*Version.*=.*"\(.*\)".*$/\1/p' ./version/version.go)
+
+echo $VERSION
+
+OPERATOR_IMAGE="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/apicurio-registry-operator:$VERSION"
+OPERATOR_METADATA_IMAGE="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/apicurio-registry-operator-metadata:$VERSION"
+
 BUNDLE_URL=${PWD}/docs/resources/install-dev.yaml
 
 git clone https://github.com/Apicurio/apicurio-registry-k8s-tests-e2e.git

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Test
         id: test
-        run: CI_BUILD=true OPERATOR_IMAGE="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/apicurio-registry-operator:latest-dev" ./.github/scripts/test_operator.sh
+        run: CI_BUILD=true ./.github/scripts/test_operator.sh
 
       - name: Collect logs
         if: failure()


### PR DESCRIPTION
This PR changes the parameters passed to kubernetes testsuite in order to test CI builds of the olm part (aka pre-release testing)

The kubernetes testsuite is responsible for replacing the operator image in the CSV