### PR TITLE
Support for configurable volumes and resources of the apicurio-registry deployment

### DIFF
--- a/api/v1/apicurioregistry_types.go
+++ b/api/v1/apicurioregistry_types.go
@@ -81,16 +81,29 @@ type ApicurioRegistrySpecConfigurationUI struct {
 }
 
 type ApicurioRegistrySpecDeployment struct {
-	Replicas    int32               `json:"replicas,omitempty"`
-	Host        string              `json:"host,omitempty"`
-	Affinity    *corev1.Affinity    `json:"affinity,omitempty"`
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	Replicas    int32                                   `json:"replicas,omitempty"`
+	Host        string                                  `json:"host,omitempty"`
+	Affinity    *corev1.Affinity                        `json:"affinity,omitempty"`
+	Tolerations []corev1.Toleration                     `json:"tolerations,omitempty"`
+	Resources   ApicurioRegistrySpecDeploymentResources `json:"resources,omitempty"`
+	Volumes     []ApicurioRegistrySpecDeploymentVolumes `json:"volumes,omitempty"`
 }
 
-//type ApicurioRegistrySpecDeploymentResources struct {
-//	Cpu    ApicurioRegistrySpecDeploymentResourcesRequestsLimit `json:"cpu,omitempty"`
-//	Memory ApicurioRegistrySpecDeploymentResourcesRequestsLimit `json:"memory,omitempty"`
-//}
+type ApicurioRegistrySpecDeploymentVolumes struct {
+	corev1.VolumeMount  `json:"volumeMount"`
+	corev1.VolumeSource `json:"volumeSource"`
+}
+
+type ApicurioRegistrySpecDeploymentResources struct {
+	Cpu    ApicurioRegistrySpecDeploymentResourcesRequestsLimits `json:"cpu,omitempty"`
+	Memory ApicurioRegistrySpecDeploymentResourcesRequestsLimits `json:"memory,omitempty"`
+}
+
+type ApicurioRegistrySpecDeploymentResourcesRequestsLimits struct {
+	Request string `json:"requests,omitempty"`
+	Limit   string `json:"limits,omitempty"`
+}
+
 //
 //type ApicurioRegistrySpecDeploymentResourcesRequestsLimit struct {
 //	Requests string `json:"requests,omitempty"`

--- a/config/crd/resources/registry.apicur.io_apicurioregistries.yaml
+++ b/config/crd/resources/registry.apicur.io_apicurioregistries.yaml
@@ -708,6 +708,19 @@ spec:
                     type: object
                   host:
                     type: string
+                  resources:
+                    requests:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      type: object
+                    limits:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
                   replicas:
                     format: int32
                     type: integer
@@ -749,6 +762,28 @@ spec:
                             to. If the operator is Exists, the value should be empty,
                             otherwise just a regular string.
                           type: string
+                      type: object
+                    type: array
+                  volumes:
+                    items:
+                      volumeMount:
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        mountPath:
+                          type: string
+                        subPath:
+                          type: string
+                        mountPropagation:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        subPathExpr:
+                          type: string
+                        type: object
+                      volumeSource:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: object
                     type: array
                 type: object

--- a/controllers/loop/services/services.go
+++ b/controllers/loop/services/services.go
@@ -16,7 +16,6 @@ type LoopServices struct {
 }
 
 func NewLoopServices(ctx *context.LoopContext) *LoopServices {
-
 	factoryKube := factory.NewKubeFactory(ctx)
 	factoryMonitoring := factory.NewMonitoringFactory(ctx, factoryKube)
 

--- a/controllers/svc/factory/factory_kube.go
+++ b/controllers/svc/factory/factory_kube.go
@@ -115,18 +115,18 @@ func (this *KubeFactory) CreateDeployment() *apps.Deployment {
 			Limits[core.ResourceMemory] = resource.MustParse("1280Mi")
 		}
 
-		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Cpu.Requests)
+		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Cpu.Request)
 		if err == nil {
-			if spec.Spec.Deployment.Resources.Cpu.Requests != "0" {
-				Requests[core.ResourceCPU] = resource.MustParse(spec.Spec.Deployment.Resources.Cpu.Requests)
+			if spec.Spec.Deployment.Resources.Cpu.Request != "0" {
+				Requests[core.ResourceCPU] = resource.MustParse(spec.Spec.Deployment.Resources.Cpu.Request)
 			}
 		} else {
 			Requests[core.ResourceCPU] = resource.MustParse("500m")
 		}
-		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Memory.Requests)
+		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Memory.Request)
 		if err == nil {
-			if spec.Spec.Deployment.Resources.Memory.Requests != "0" {
-				Requests[core.ResourceMemory] = resource.MustParse(spec.Spec.Deployment.Resources.Memory.Requests)
+			if spec.Spec.Deployment.Resources.Memory.Request != "0" {
+				Requests[core.ResourceMemory] = resource.MustParse(spec.Spec.Deployment.Resources.Memory.Request)
 			}
 		} else {
 			Requests[core.ResourceMemory] = resource.MustParse("512Mi")

--- a/controllers/svc/factory/factory_kube.go
+++ b/controllers/svc/factory/factory_kube.go
@@ -5,6 +5,7 @@ import (
 
 	ar "github.com/Apicurio/apicurio-registry-operator/api/v1"
 	"github.com/Apicurio/apicurio-registry-operator/controllers/loop/context"
+	"github.com/Apicurio/apicurio-registry-operator/controllers/svc/resources"
 	"github.com/Apicurio/apicurio-registry-operator/controllers/svc/status"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -75,6 +76,62 @@ func (this *KubeFactory) createObjectMeta(typeTag string) meta.ObjectMeta {
 func (this *KubeFactory) CreateDeployment() *apps.Deployment {
 	var terminationGracePeriodSeconds int64 = 30
 	var replicas int32 = 1
+	var Limits, Requests core.ResourceList
+	var vol []core.Volume
+	var volMnt []core.VolumeMount
+
+	specEntry, specExists := this.ctx.GetResourceCache().Get(resources.RC_KEY_SPEC)
+	if specExists {
+		spec := specEntry.GetValue().(*ar.ApicurioRegistry)
+		for _, addVol := range spec.Spec.Deployment.Volumes {
+			vol = append(vol, core.Volume{
+				Name:         addVol.Name,
+				VolumeSource: addVol.VolumeSource,
+			})
+			volMnt = append(volMnt, core.VolumeMount{
+				Name:             addVol.Name,
+				ReadOnly:         addVol.ReadOnly,
+				MountPath:        addVol.MountPath,
+				SubPath:          addVol.SubPath,
+				MountPropagation: addVol.MountPropagation,
+				SubPathExpr:      addVol.SubPathExpr,
+			})
+		}
+
+		_, err := resource.ParseQuantity(spec.Spec.Deployment.Resources.Cpu.Limit)
+		if err == nil {
+			if spec.Spec.Deployment.Resources.Cpu.Limit != "0" {
+				Limits[core.ResourceCPU] = resource.MustParse(spec.Spec.Deployment.Resources.Cpu.Limit)
+			}
+		} else {
+			Limits[core.ResourceCPU] = resource.MustParse("1")
+		}
+		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Memory.Limit)
+		if err == nil {
+			if spec.Spec.Deployment.Resources.Memory.Limit != "0" {
+				Limits[core.ResourceMemory] = resource.MustParse(spec.Spec.Deployment.Resources.Memory.Limit)
+			}
+		} else {
+			Limits[core.ResourceMemory] = resource.MustParse("1280Mi")
+		}
+
+		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Cpu.Requests)
+		if err == nil {
+			if spec.Spec.Deployment.Resources.Cpu.Requests != "0" {
+				Requests[core.ResourceCPU] = resource.MustParse(spec.Spec.Deployment.Resources.Cpu.Requests)
+			}
+		} else {
+			Requests[core.ResourceCPU] = resource.MustParse("500m")
+		}
+		_, err = resource.ParseQuantity(spec.Spec.Deployment.Resources.Memory.Requests)
+		if err == nil {
+			if spec.Spec.Deployment.Resources.Memory.Requests != "0" {
+				Requests[core.ResourceMemory] = resource.MustParse(spec.Spec.Deployment.Resources.Memory.Requests)
+			}
+		} else {
+			Requests[core.ResourceMemory] = resource.MustParse("512Mi")
+		}
+	}
 
 	return &apps.Deployment{
 		ObjectMeta: this.createObjectMeta("deployment"),
@@ -97,14 +154,8 @@ func (this *KubeFactory) CreateDeployment() *apps.Deployment {
 						},
 						Env: []core.EnvVar{},
 						Resources: core.ResourceRequirements{
-							Limits: core.ResourceList{
-								core.ResourceCPU:    resource.MustParse("1"),
-								core.ResourceMemory: resource.MustParse("1300Mi"),
-							},
-							Requests: core.ResourceList{
-								core.ResourceCPU:    resource.MustParse("500m"),
-								core.ResourceMemory: resource.MustParse("512Mi"),
-							},
+							Limits:   Limits,
+							Requests: Requests,
 						},
 						LivenessProbe: &core.Probe{
 							Handler: core.Handler{
@@ -134,10 +185,12 @@ func (this *KubeFactory) CreateDeployment() *apps.Deployment {
 						},
 						TerminationMessagePath: "/dev/termination-log",
 						ImagePullPolicy:        core.PullAlways,
+						VolumeMounts:           volMnt,
 					}},
 					RestartPolicy:                 core.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					DNSPolicy:                     core.DNSClusterFirst,
+					Volumes:                       vol,
 				},
 			},
 			Strategy: apps.DeploymentStrategy{


### PR DESCRIPTION
#120

Main purpose of this PR is to add in support for configurable volumes to the apicurio-registry deployment.

The resource support adds in the ability to not set requests or limits for CPU or memory as appropriate using "0". Resources will still default to what they are currently.