### PR TITLE
add tmp volume to deployment

### DIFF
--- a/controllers/svc/factory/factory_kube.go
+++ b/controllers/svc/factory/factory_kube.go
@@ -134,10 +134,22 @@ func (this *KubeFactory) CreateDeployment() *apps.Deployment {
 						},
 						TerminationMessagePath: "/dev/termination-log",
 						ImagePullPolicy:        core.PullAlways,
+						VolumeMounts: []core.VolumeMount{
+							core.VolumeMount{
+								Name:      "tmp",
+								MountPath: "/tmp",
+							},
+						},
 					}},
 					RestartPolicy:                 core.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					DNSPolicy:                     core.DNSClusterFirst,
+					Volumes: []core.Volume{
+						core.Volume{
+							Name:         "tmp",
+							VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}},
+						},
+					},
 				},
 			},
 			Strategy: apps.DeploymentStrategy{


### PR DESCRIPTION
#120 

Quick and easy solution since apicurio-registry won't work when deployed with a ReadOnlyRootFilesystem.