### PR TITLE
feat: Allow specification of pod image

### DIFF
--- a/api/v1/apicurioregistry_types.go
+++ b/api/v1/apicurioregistry_types.go
@@ -99,6 +99,8 @@ type ApicurioRegistrySpecDeployment struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Metadata applied to the Deployment pod template.
 	Metadata ApicurioRegistrySpecDeploymentMetadata `json:"metadata,omitempty"`
+	// Image set in the Deployment pod template. Overrides the values in the REGISTRY_IMAGE_MEM, REGISTRY_IMAGE_KAFKASQL and REGISTRY_IMAGE_SQL operator environment variables.
+	Image string `json:"image,omitempty"`
 }
 
 // ### Status

--- a/config/crd/resources/registry.apicur.io_apicurioregistries.yaml
+++ b/config/crd/resources/registry.apicur.io_apicurioregistries.yaml
@@ -721,6 +721,11 @@ spec:
                     type: object
                   host:
                     type: string
+                  image:
+                    description: Image set in the Deployment pod template. Overrides
+                      the values in the REGISTRY_IMAGE_MEM, REGISTRY_IMAGE_KAFKASQL
+                      and REGISTRY_IMAGE_SQL operator environment variables.
+                    type: string
                   metadata:
                     description: Metadata applied to the Deployment pod template.
                     properties:

--- a/controllers/cf/cf_image.go
+++ b/controllers/cf/cf_image.go
@@ -1,8 +1,9 @@
 package cf
 
 import (
-	"github.com/Apicurio/apicurio-registry-operator/controllers/loop/services"
 	"os"
+
+	"github.com/Apicurio/apicurio-registry-operator/controllers/loop/services"
 
 	ar "github.com/Apicurio/apicurio-registry-operator/api/v1"
 	"github.com/Apicurio/apicurio-registry-operator/controllers/loop"
@@ -74,26 +75,29 @@ func (this *ImageCF) Sense() {
 	if specEntry, exists := this.svcResourceCache.Get(resources.RC_KEY_SPEC); exists {
 		spec := specEntry.GetValue().(*ar.ApicurioRegistry).Spec
 		this.persistence = spec.Configuration.Persistence
+		this.targetImage = spec.Deployment.Image
 	}
 
-	envImage := ""
-	this.persistenceError = false
-	switch this.persistence {
-	case "", "mem":
-		envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_MEM)
-	case "kafkasql":
-		envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_KAFKASQL)
-	case "sql":
-		envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_SQL)
-	}
-	if envImage != "" {
-		this.targetImage = envImage
-	} else {
-		this.persistenceError = true
-		this.ctx.GetLog().WithValues("type", "Warning").
-			Info("WARNING: The operand image is not selected. " +
-				"Set the 'spec.configuration.persistence' property in your 'apicurioregistry' resource " +
-				"to select the appropriate Service Registry image.")
+	if this.targetImage == "" {
+		envImage := ""
+		this.persistenceError = false
+		switch this.persistence {
+		case "", "mem":
+			envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_MEM)
+		case "kafkasql":
+			envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_KAFKASQL)
+		case "sql":
+			envImage = os.Getenv(ENV_OPERATOR_REGISTRY_IMAGE_SQL)
+		}
+		if envImage != "" {
+			this.targetImage = envImage
+		} else {
+			this.persistenceError = true
+			this.ctx.GetLog().WithValues("type", "Warning").
+				Info("WARNING: The operand image is not selected. " +
+					"Set the 'spec.configuration.persistence' property in your 'apicurioregistry' resource " +
+					"to select the appropriate Service Registry image.")
+		}
 	}
 
 	// Update state


### PR DESCRIPTION
... via new `spec.deployment.image` field, which overrides the values
set in the `REGISTRY_IMAGE_MEM`, `REGISTRY_IMAGE_KAFKASQL` or
`REGISTRY_IMAGE_SQL` operator environment variables.

Contributes to: #154

Signed-off-by: Andrew Borley <BORLEY@uk.ibm.com>