### PR TITLE
Close the body after http.Get()

### DIFF
--- a/controllers/cf/condition/cf_app_health.go
+++ b/controllers/cf/condition/cf_app_health.go
@@ -50,12 +50,14 @@ func (this *AppHealthCF) Sense() {
 	this.requestLivenessOk = false
 	if this.targetType == core.ServiceTypeClusterIP && this.targetIP != "" {
 		if res, err := http.Get("http://" + this.targetIP + ":8080/health/ready"); err == nil {
+			defer res.Body.Close()
 			if res.StatusCode == 200 {
 				this.requestReadinessOk = true
 				this.initializing = false
 			}
 		}
 		if res, err := http.Get("http://" + this.targetIP + ":8080/health/live"); err == nil {
+			defer res.Body.Close()
 			if res.StatusCode == 200 {
 				this.requestLivenessOk = true
 			}

--- a/controllers/cf/condition/cf_initializing.go
+++ b/controllers/cf/condition/cf_initializing.go
@@ -54,6 +54,7 @@ func (this *InitializingCF) Sense() {
 	if this.targetType == core.ServiceTypeClusterIP && this.targetIP != "" {
 		res, err := http.Get("http://" + this.targetIP + ":8080")
 		if err == nil {
+			defer res.Body.Close()
 			if res.StatusCode >= 200 && res.StatusCode < 300 {
 				this.requestOk = true
 			}


### PR DESCRIPTION
Currently, the operator is leaking memory by not closing the TCP
connection properly.