### PR TITLE
docs(#2684): use cleanup.policy=compact

### DIFF
--- a/docs/modules/ROOT/partials/proc-persistence-kafka-streams-plain.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafka-streams-plain.adoc
@@ -77,8 +77,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Change the topic name to `global-id-topic`, and optionally decrease the partition and replica count to minimum, which is sufficient for an example deployment.

--- a/docs/modules/ROOT/partials/proc-persistence-kafka-streams-scram.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafka-streams-scram.adoc
@@ -69,8 +69,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Change the topic name to `global-id-topic`, and optionally decrease the partition and replica count to minimum, which is sufficient for an example deployment.

--- a/docs/modules/ROOT/partials/proc-persistence-kafka-streams-tls.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafka-streams-tls.adoc
@@ -68,8 +68,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Change the topic name to `global-id-topic`, and optionally decrease the partition and replica count to minimum, which is sufficient for an example deployment.


### PR DESCRIPTION
Use cleanup.policy=compact as this is default for the schema registry indicated here https://github.com/Apicurio/apicurio-registry/blob/2.2.5.Final/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java#L225

Solves https://github.com/Apicurio/apicurio-registry/issues/2684