### PR TITLE
docs(#2684): use cleanup.policy=compact

### DIFF
--- a/docs/modules/ROOT/partials/proc-persistence-kafkasql-plain.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafkasql-plain.adoc
@@ -95,8 +95,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Select the *{operator}*, and in the *ApicurioRegistry* tab, click *Create ApicurioRegistry*, using the following example, but replace your value in the `bootstrapServers` field.

--- a/docs/modules/ROOT/partials/proc-persistence-kafkasql-scram.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafkasql-scram.adoc
@@ -83,8 +83,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Create a *Kafka User* resource to configure SCRAM authentication and authorization for the {registry} user. You can specify a user name in the `metadata` section or use the default `my-user`.

--- a/docs/modules/ROOT/partials/proc-persistence-kafkasql-tls.adoc
+++ b/docs/modules/ROOT/partials/proc-persistence-kafkasql-tls.adoc
@@ -82,8 +82,7 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
+    cleanup.policy: compact
 ----
 
 . Create a *Kafka User* resource to configure authentication and authorization for the {registry} user. You can specify a user name in the `metadata` section or use the default `my-user`.


### PR DESCRIPTION
Use cleanup.policy=compact as this is default for the schema registry indicated here https://github.com/Apicurio/apicurio-registry/blob/2.2.5.Final/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java#L225

Solves https://github.com/Apicurio/apicurio-registry/issues/2684