### PR TITLE
docs: remove tp notice for sso

### DIFF
--- a/docs/modules/ROOT/partials/proc-manage-environment-variables.adoc
+++ b/docs/modules/ROOT/partials/proc-manage-environment-variables.adoc
@@ -7,7 +7,7 @@
 
 OpenShift web console::
 
-. Select the *Installed Operators* tab, and then the *Red Hat Integration - {operator}*.
+. Select the *Installed Operators* tab, and then the *{prodnamefull} - {operator}*.
 . On the *Apicurio Registry* tab, click the `ApicurioRegistry` CR for your {registry} deployment.
 . On the main overview page, view the `managedResources` section, which contains the name of the `Deployment` managed by the Operator to deploy your {registry} instance.
 . Find that `Deployment` in the *Workloads* > *Deployments* in the left menu.

--- a/docs/modules/ROOT/partials/proc-registry-security-keycloak.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-security-keycloak.adoc
@@ -2,16 +2,6 @@
 = Securing {registry} using the {keycloak} Operator
 
 The following procedure shows how to configure a {registry} REST API and web console to be protected by {keycloak}.
-ifdef::rh-service-registry[]
-The {keycloak} Operator is available as a Technology Preview feature.
-
-[IMPORTANT]
-====
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend implementing any Technology Preview features in production environments.
-
-This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::[]
 
 {registry} supports the following user roles:
 

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -38,6 +38,8 @@ ifdef::apicurio-registry-operator-downstream[]
 
 :service-registry:
 
+:org-name: Red Hat
+:prodnamefull: {org-name} Integration
 :registry: Service Registry
 :operator: {registry} Operator
 
@@ -49,7 +51,7 @@ ifdef::apicurio-registry-operator-downstream[]
 
 :kafka-streams: AMQ Streams
 
-:keycloak: Red Hat Single Sign-On
+:keycloak: {org-name} Single Sign-On
 
 endif::[]
 


### PR DESCRIPTION
Remove Technology Preview notice for RH-SSO Operator (no longer applies, GA feature since RH-SSO v7.5)