### PR TITLE
Fix Keycloak doc examples for OCP 4.9

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 /target/
+*.csv

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,1 @@
 /target/
-*.csv

--- a/docs/modules/ROOT/examples/keycloak/keycloak_http_ingress.yaml
+++ b/docs/modules/ROOT/examples/keycloak/keycloak_http_ingress.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: networking.k8s.io/v1beta1
+﻿apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak-http
@@ -6,11 +6,13 @@ metadata:
     app: keycloak
 spec:
   rules:
-    - host: keycloak-http.local
+    - host: KEYCLOAK_HTTP_HOST
       http:
         paths:
           - path: /
             pathType: ImplementationSpecific
             backend:
-              serviceName: keycloak-http
-              servicePort: 8080
+              service:
+                name: keycloak-http
+                port:
+                  number: 8080

--- a/docs/modules/ROOT/examples/keycloak/keycloak_realm.yaml
+++ b/docs/modules/ROOT/examples/keycloak/keycloak_realm.yaml
@@ -2,6 +2,8 @@ apiVersion: keycloak.org/v1alpha1
 kind: KeycloakRealm
 metadata:
   name: registry-keycloakrealm
+  labels:
+    app: registry
 spec:
   instanceSelector:
     matchLabels:

--- a/docs/modules/ROOT/pages/assembly-operator-configuration.adoc
+++ b/docs/modules/ROOT/pages/assembly-operator-configuration.adoc
@@ -8,8 +8,8 @@ This chapter provides detailed information on the custom resource used to config
 * xref:apicurio-registry-custom-resource[]
 * xref:spec[]
 * xref:status[]
-* xref:registry-labels[]
 * xref:managed-resources[]
+* xref:registry-labels[]
 
 // INCLUDES
 include::partial$ref-registry-cr.adoc[leveloffset=+1]

--- a/docs/modules/ROOT/partials/proc-manage-environment-variables.adoc
+++ b/docs/modules/ROOT/partials/proc-manage-environment-variables.adoc
@@ -7,7 +7,12 @@
 
 OpenShift web console::
 
-. Select the *Installed Operators* tab, and then the *{prodnamefull} - {operator}*.
+ifdef::apicurio-registry[]
+. Select the *Installed Operators* tab, and then *{registry} Operator*.
+endif::[]
+ifdef::rh-service-registry[]
+. Select the *Installed Operators* tab, and then *Red Hat Integration - Service Registry Operator*.
+endif::[]
 . On the *Apicurio Registry* tab, click the `ApicurioRegistry` CR for your {registry} deployment.
 . On the main overview page, view the `managedResources` section, which contains the name of the `Deployment` managed by the Operator to deploy your {registry} instance.
 . Find that `Deployment` in the *Workloads* > *Deployments* in the left menu.

--- a/docs/modules/ROOT/partials/proc-registry-operator-quickstart-sr.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-operator-quickstart-sr.adoc
@@ -9,11 +9,11 @@ You can quickly deploy the {operator} on the command line, without the Operator 
 
 .Procedure
 
-. Create a project for the installation, for example, `service-registry`:
+. Create a project for the installation, for example, `apicurio-registry`:
 +
 [source,bash]
 ----
-NAMESPACE="service-registry"
+NAMESPACE="apicurio-registry"
 oc new-project "$NAMESPACE"
 ----
 

--- a/docs/modules/ROOT/partials/shared/attributes-links.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes-links.adoc
@@ -2,13 +2,13 @@
 
 // Downstream
 :LinkRedHatIntegrationDownloads: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=red.hat.integration
-:NameRedHatIntegrationDownloads: Red Hat Integration Downloads
+:NameRedHatIntegrationDownloads: Red Hat Software Downloads
 
-:LinkOLMDocs: https://docs.openshift.com/container-platform/4.6/operators/understanding/olm/olm-understanding-olm.html
+:LinkOLMDocs: https://docs.openshift.com/container-platform/4.11/operators/understanding/olm/olm-understanding-olm.html
 :NameOLMDocs: Operator Lifecycle Manager
 
-:LinkOperatorHub: https://docs.openshift.com/container-platform/4.6/operators/understanding/olm-understanding-operatorhub.html
+:LinkOperatorHub: https://docs.openshift.com/container-platform/4.11/operators/understanding/olm-understanding-operatorhub.html
 :NameOperatorHub: OperatorHub
 
-:LinkManagingContentUsingRESTAPI: https://access.redhat.com/documentation/en-us/red_hat_integration/2021.q2/html/service_registry_user_guide/managing-registry-artifacts-api
-:NameManagingContentUsingRESTAPI: Managing Apicurio Registry content using the REST API
+:LinkManagingContentUsingRESTAPI: https://access.redhat.com/documentation/en-us/red_hat_integration/2022.q3/html/service_registry_user_guide/managing-registry-artifacts-api_registry
+:NameManagingContentUsingRESTAPI: Managing {registry} content using the REST API

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -40,6 +40,7 @@ ifdef::apicurio-registry-operator-downstream[]
 
 :org-name: Red Hat
 :prodnamefull: {org-name} Integration
+:registry-name-full: {prodnamefull} - Service Registry
 :registry: Service Registry
 :operator: {registry} Operator
 
@@ -48,10 +49,14 @@ ifdef::apicurio-registry-operator-downstream[]
 
 :platform: OpenShift
 :cli-client: oc
-
 :kafka-streams: AMQ Streams
-
 :keycloak: {org-name} Single Sign-On
+
+ifdef::RHAF[]
+:prodnamefull: {org-name} Application Foundations
+:registry-name-full:{org-name} build of Apicurio Registry
+:registry: Apicurio Registry
+endif::[]
 
 endif::[]
 


### PR DESCRIPTION
- Fix keycloak example `.yaml` files
- Clean up from downstream testing