### PR TITLE
docs: improve quickstart steps after testing, clean up

### DIFF
--- a/docs/modules/ROOT/examples/apicurioregistry_kafkasql_scram_cr.yaml
+++ b/docs/modules/ROOT/examples/apicurioregistry_kafkasql_scram_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: registry.apicur.io/v1
 kind: ApicurioRegistry
 metadata:
-  name: example-apicurioregistry-kafkasql
+  name: example-apicurioregistry-kafkasql-scram
 spec:
   configuration:
     persistence: "kafkasql"

--- a/docs/modules/ROOT/examples/apicurioregistry_kafkasql_tls_cr.yaml
+++ b/docs/modules/ROOT/examples/apicurioregistry_kafkasql_tls_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: registry.apicur.io/v1
 kind: ApicurioRegistry
 metadata:
-  name: example-apicurioregistry-kafkasql
+  name: example-apicurioregistry-kafkasql-tls
 spec:
   configuration:
     persistence: "kafkasql"

--- a/docs/modules/ROOT/pages/assembly-operator-quickstart.adoc
+++ b/docs/modules/ROOT/pages/assembly-operator-quickstart.adoc
@@ -3,19 +3,19 @@ include::partial$shared/all-attributes.adoc[]
 [id="operator-quickstart"]
 = {operator} quickstart
 
-This chapter explains how to quickly install {operator} on the command line.
+You can quickly install the {operator} on the command line by using Custom Resource Definitions (CRDs).
 
 ifdef::service-registry[]
-This quickstart example deploys {registry} using the SQL database storage option:
+The quickstart example deploys {registry} with storage in an SQL database:
 endif::[]
 ifdef::apicurio-registry[]
-This quickstart example deploys {registry} using the in-memory storage option:
+The quickstart example deploys {registry} with in-memory storage:
 endif::[]
 
 * xref:registry-operator-quickstart[]
 * xref:registry-quickstart[]
 
-NOTE: The recommended installation option for production environments is using the OpenShift OperatorHub. The recommended storage option is SQL or Kafka.
+NOTE: The recommended installation option for production environments is the OpenShift OperatorHub. The recommended storage option is an SQL database for performance, stability, and data management. 
 
 // INCLUDES
 ifdef::service-registry[]

--- a/docs/modules/ROOT/pages/assembly-registry-storage.adoc
+++ b/docs/modules/ROOT/pages/assembly-registry-storage.adoc
@@ -11,10 +11,11 @@ ifdef::apicurio-registry[]
 * xref:registry-persistence-mem[]
 endif::[]
 
+* xref:registry-persistence-sql[]
 * xref:registry-persistence-kafkasql-plain[]
 * xref:registry-persistence-kafkasql-tls[]
 * xref:registry-persistence-kafkasql-scram[]
-* xref:registry-persistence-sql[]
+
 
 ifdef::apicurio-registry[]
 NOTE: This chapter mostly focuses on storage configuration procedures for OpenShift using OperatorHub UI.
@@ -28,8 +29,8 @@ include::partial$con-persistence-options.adoc[leveloffset=+1]
 ifdef::apicurio-registry[]
 include::partial$proc-persistence-mem.adoc[leveloffset=+1]
 endif::[]
-
+include::partial$proc-persistence-sql.adoc[leveloffset=+1]
 include::partial$proc-persistence-kafkasql-plain.adoc[leveloffset=+1]
 include::partial$proc-persistence-kafkasql-tls.adoc[leveloffset=+1]
 include::partial$proc-persistence-kafkasql-scram.adoc[leveloffset=+1]
-include::partial$proc-persistence-sql.adoc[leveloffset=+1]
+

--- a/docs/modules/ROOT/partials/con-persistence-options.adoc
+++ b/docs/modules/ROOT/partials/con-persistence-options.adoc
@@ -5,20 +5,36 @@ The main decision to make when deploying {registry} is which storage backend to 
 
 The following storage options are available:
 
+.{registry} data storage options
+[%header,cols="1,3"] 
+|===
+|Storage option
+|Description
+
 ifdef::apicurio-registry[]
-* *In-memory* - data is stored in RAM on each {registry} node.
-This is the easiest deployment to use, but is not recommended for production environment.
+|In-memory
+|Data is stored in RAM on each {registry} node. This is the easiest deployment to use, but is not recommended for production environment. All data is lost when restarting {registry} with this storage option, which is suitable for a development environment only. 
 endif::[]
-* *Apache Kafka* (Kafka + SQL) - data is stored using Apache Kafka, with the help of local SQL database
-on each node.
-* *SQL* (PostgreSQL) - data is stored in a relational database, in this case PostgreSQL 12+.
+
+|SQL database  
+|Data is stored in a relational database, in this case PostgreSQL 12+. This is the recommended storage option in a production environment for performance, stability, and data management (backup/restore, and so on).
+
+ifdef::apicurio-registry[]
+|Apache Kafka 
+endif::[]
+ifdef::rh-service-registry[]
+|{kafka-streams} 
+endif::[]
+|Data is stored using Apache Kafka, with the help of a local SQL database on each node. This storage option is provided for production environments where database management expertise is not available, or where storage in Kafka is a specific requirement.
+|===
+
 
 ifdef::apicurio-registry[]
 .Storage requiring installation
 The following options require that the storage is already installed as a prerequisite:
 
-* *Apache Kafka*
-* *SQL* (PostgreSQL)
+* SQL (PostgreSQL)
+* Apache Kafka
 endif::[]
 
 ifdef::service-registry[]

--- a/docs/modules/ROOT/partials/proc-registry-operator-distribution-bundle-ar.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-operator-distribution-bundle-ar.adoc
@@ -1,9 +1,8 @@
 [id="registry-operator-distribution-bundle"]
-= {operator} Distribution Bundle
+= {operator} distribution bundle
 
-Since version `1.0.0`, {operator} project is distributed with an additional archive file containing installation files for the operator, with example `ApicurioRegistry` custom resource files.
-In addition, full Operator documentation and license information is also included.
+Since version `1.0.0`, the {operator} project is distributed with an additional archive file containing installation files for the Operator, with example `ApicurioRegistry` custom resource files. In addition, full {operator} documentation and license information are included. 
+
 Docker images for the Operator and the Operand are distributed using a public registry.
 
-For released versions, you can find this file in the https://github.com/Apicurio/apicurio-registry-operator/releases[{operator} releases page].
-Visit the https://github.com/Apicurio/apicurio-registry-operator/[{operator} GitHub repository] for information about how to build the bundle for development versions.
+For released versions, you can find the distribution on the https://github.com/Apicurio/apicurio-registry-operator/tags[{operator} releases page]. For information about how to build the bundle for development versions, see the https://github.com/Apicurio/apicurio-registry-operator/[{operator} GitHub repository]. 

--- a/docs/modules/ROOT/partials/proc-registry-operator-quickstart-sr.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-operator-quickstart-sr.adoc
@@ -1,15 +1,20 @@
 [id="registry-operator-quickstart"]
 = Quickstart {operator} installation
 
-You can quickly deploy the {operator} on the command line, without the Operator Lifecycle Manager, by using a downloaded set of installation files and examples.
+You can quickly deploy the {operator} on the command line, without the Operator Lifecycle Manager, by using a downloaded set of installation files and example Custom Resource Definitions (CRDs). 
 
 .Prerequisites
 
-* You must go to link:{LinkRedHatIntegrationDownloads}[{NameRedHatIntegrationDownloads}], select the product version, and download the examples in the {registry} CRDs `.zip` file.
+* You are logged into an OpenShift cluster with administrator access.
+* You have the OpenShift `oc` command-line client installed. For more details, see the {LinkOCPCLIDocs}[{NameOCPCLIDocs}].
 
 .Procedure
 
-. Create a project for the installation, for example, `apicurio-registry`:
+. Browse to link:{LinkRedHatIntegrationDownloads}[{NameRedHatIntegrationDownloads}], select the product version, and download the examples in the {registry} CRDs `.zip` file.
+
+. Extract the downloaded CRDs `.zip` file and change to the `apicurio-registry-install-examples` directory.
+
+. Create an OpenShift project for the {registry} installation, for example:
 +
 [source,bash]
 ----
@@ -17,7 +22,7 @@ NAMESPACE="apicurio-registry"
 oc new-project "$NAMESPACE"
 ----
 
-. Apply the file located in the `install/` folder:
+. Apply the example CRD specified in the `/install/install.yaml` file:
 +
 [source,bash]
 ----

--- a/docs/modules/ROOT/partials/proc-registry-quickstart-sr.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-quickstart-sr.adoc
@@ -1,28 +1,40 @@
 [id="registry-quickstart"]
 = Quickstart {registry} deployment
 
-To create a new {registry} deployment, use the SQL database storage option. This requires external PostgreSQL storage to be configured as a prerequisite.
+To create a new {registry} deployment,use the SQL database storage option to connect to an existing PostgreSQL database. 
 
 .Prerequisites
-* Ensure that the {operator} is already installed.
-* You have a PostgreSQL database reachable from your OpenShift cluster.
+* Ensure that the {operator} is installed.
+* You have a PostgreSQL database that is reachable from your OpenShift cluster.  
 
 .Procedure
-. Create an `ApicurioRegistry` custom resource (CR), with your database connection configured, for example:
+. Edit the `./examples/apicurioregistry_sql_cr.yaml` file, which contains the `ApicurioRegistry` custom resource (CR):
 +
 .Example CR for SQL storage
 [source,yaml]
 ----
-include::example$/apicurioregistry_sql_cr.yaml[]
+include::../examples/apicurioregistry_sql_cr.yaml[]
 ----
 
-. Create the `ApicurioRegistry` CR in the same namespace that the Operator is deployed
+. In the `dataSource` section, replace the example settings with your database connection details. For example:
++
+[source,yaml]
+----
+dataSource:
+    url: "jdbc:postgresql://postgresql.apicurio-registry.svc:5432/registry"
+    userName: "pgadmin"
+    password: "pgpass"
+----
+
+. Apply the updated `ApicurioRegistry` CR in the same namespace as the {registry} Operator, and wait for the {registry} instance to deploy:
 +
 [source,bash]
 ----
 oc project "$NAMESPACE"
 oc apply -f ./examples/apicurioregistry_sql_cr.yaml
 ----
+
+. In the OpenShift web console, click *Developer* -> *Topology* -> *example-apicurioregistry-sql-deployment* -> *Routes*, and click the URL to launch the {registry} web console.   
 
 ifdef::apicurio-registry[]
 .Additional resources

--- a/docs/modules/ROOT/partials/proc-registry-quickstart-sr.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-quickstart-sr.adoc
@@ -8,12 +8,12 @@ To create a new {registry} deployment,use the SQL database storage option to con
 * You have a PostgreSQL database that is reachable from your OpenShift cluster.  
 
 .Procedure
-. Edit the `./examples/apicurioregistry_sql_cr.yaml` file, which contains the `ApicurioRegistry` custom resource (CR):
+. Edit the `../examples/apicurioregistry_sql_cr.yaml` file, which contains the `ApicurioRegistry` custom resource (CR):
 +
 .Example CR for SQL storage
 [source,yaml]
 ----
-include::../examples/apicurioregistry_sql_cr.yaml[]
+include::example$/apicurioregistry_sql_cr.yaml[]
 ----
 
 . In the `dataSource` section, replace the example settings with your database connection details. For example:

--- a/docs/modules/ROOT/partials/shared/attributes-links.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes-links.adoc
@@ -10,5 +10,8 @@
 :LinkOperatorHub: https://docs.openshift.com/container-platform/4.11/operators/understanding/olm-understanding-operatorhub.html
 :NameOperatorHub: OperatorHub
 
+:LinkOCPCLIDocs: https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/getting-started-cli.html
+:NameOCPCLIDocs: OpenShift CLI documentation
+
 :LinkManagingContentUsingRESTAPI: https://access.redhat.com/documentation/en-us/red_hat_integration/2022.q3/html/service_registry_user_guide/managing-registry-artifacts-api_registry
 :NameManagingContentUsingRESTAPI: Managing {registry} content using the REST API


### PR DESCRIPTION
- Add missing prerequisite for `oc` install
- Add a few missing steps (unzip CRD download, edit DB connection, launch web console to verify) 
- Some minor doc clean up
- Tested on OCP v4.11