### PR TITLE
Add `env` to ApicurioRegistry schema

### DIFF
--- a/install/apicurio-registry-operator-1.1.0-dev.yaml
+++ b/install/apicurio-registry-operator-1.1.0-dev.yaml
@@ -36,6 +36,15 @@ spec:
             properties:
               configuration:
                 properties:
+                  env:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: 
+                          type: string
+                        value:
+                          type: string
                   kafkasql:
                     properties:
                       bootstrapServers:


### PR DESCRIPTION
This [PR](https://github.com/Apicurio/apicurio-registry-operator/pull/188/files#diff-a6d4c00bedaf79d81e5c015edf1187a52dbed73df5694cbe5ea67611960eee46R9) adds support for setting of general deployment environment variables in the CR. However, when I try to apply the manifest shown below, I get the following error
```
error: error validating "../config/examples/resources/apicurioregistry_kafkasql_cr.yaml": error validating data: ValidationError(ApicurioRegistry.spec.configuration): unknown field "env" in io.apicur.registry.v1.ApicurioRegistry.spec.configuration; if you choose to ignore these errors, turn validation off with --validate=false
```

```
apiVersion: registry.apicur.io/v1
kind: ApicurioRegistry
metadata:
  name: example-apicurioregistry-kafkasql
spec:
  configuration:
    env:
      - name: VAR_1_NAME
        value: VAR_1_VALUE
    persistence: "kafkasql"
    kafkasql:
      bootstrapServers: "<service name>.<namespace>.svc:9092"
```

Adding the `env` schema in this PR and re-installing the operator resolves the issue and I was able able to apply the manifest successfully.

```
kubectl describe apicurioregistries example-apicurioregistry-kafkasql
Name:         example-apicurioregistry-kafkasql
...
Spec:
  Configuration:
    Env:
      Name:   VAR_1_NAME
      Value:  VAR_1_VALUE
    Kafkasql:
      Bootstrap Servers:  <service name>.<namespace>.svc:9092
```

```
kubectl describe pod example-apicurioregistry-kafkasql-deployment-59cc65b584-tgx4v
Name:         example-apicurioregistry-kafkasql-deployment-59cc65b584-tgx4v
...
Containers:
  example-apicurioregistry-kafkasql:
    Container ID:   docker://07837546d12d92a50e7348829171b2b8f569e9664c4e9a0a2977fa70508b646b
    Image:          quay.io/apicurio/apicurio-registry-kafkasql:latest-snapshot
    Image ID:       docker-pullable://quay.io/apicurio/apicurio-registry-kafkasql@sha256:71bcce5736418d6a262e57a94937c64c69ca9800921ad7347c48e9a7b0b9efc0
    Port:           8080/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Tue, 21 Mar 2023 10:02:59 -0700
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Tue, 21 Mar 2023 09:57:49 -0700
      Finished:     Tue, 21 Mar 2023 09:57:55 -0700
    Ready:          False
    Restart Count:  16
    Limits:
      cpu:     1
      memory:  1300Mi
    Requests:
      cpu:      500m
      memory:   512Mi
    Liveness:   http-get http://:8080/health/live delay=15s timeout=5s period=10s #success=1 #failure=3
    Readiness:  http-get http://:8080/health/ready delay=15s timeout=5s period=10s #success=1 #failure=3
    Environment:
      VAR_1_NAME:               VAR_1_VALUE
      QUARKUS_PROFILE:          prod
      KAFKA_BOOTSTRAP_SERVERS:  <service name>.<namespace>.svc:9092
```