### PR TITLE
docs: update keycloak server url in operator docs and examples

### DIFF
--- a/docs/modules/ROOT/examples/keycloak/apicurioregistry_kafkasql_keycloak_cr.yaml
+++ b/docs/modules/ROOT/examples/keycloak/apicurioregistry_kafkasql_keycloak_cr.yaml
@@ -6,9 +6,8 @@ spec:
   configuration:
     security:
       keycloak:
-        url: "http://keycloak-http-<namespace>.apps.<cluster host>/auth"
+        url: "http://keycloak-http-<namespace>.apps.<cluster host>"
         # ^ Required
-        # Keycloak server URL, must end with `/auth`.
         # Use an HTTP URL in development.
         realm: "registry"
         # apiClientId: "registry-client-api"

--- a/docs/modules/ROOT/examples/keycloak/apicurioregistry_mem_keycloak_cr.yaml
+++ b/docs/modules/ROOT/examples/keycloak/apicurioregistry_mem_keycloak_cr.yaml
@@ -6,9 +6,8 @@ spec:
   configuration:
     security:
       keycloak:
-        url: "http://keycloak-http-<namespace>.apps.<cluster host>/auth"
+        url: "http://keycloak-http-<namespace>.apps.<cluster host>"
         # ^ Required
-        # Keycloak server URL, must end with `/auth`.
         # Use an HTTP URL in development.
         realm: "registry"
         # apiClientId: "registry-client-api"

--- a/docs/modules/ROOT/examples/keycloak/apicurioregistry_sql_keycloak_cr.yaml
+++ b/docs/modules/ROOT/examples/keycloak/apicurioregistry_sql_keycloak_cr.yaml
@@ -13,9 +13,8 @@ spec:
         # ^ Optional
     security:
       keycloak:
-        url: "http://keycloak-http-<namespace>.apps.<cluster host>/auth"
+        url: "http://keycloak-http-<namespace>.apps.<cluster host>"
         # ^ Required
-        # Keycloak server URL, must end with `/auth`.
         # Use an HTTP URL in development.
         realm: "registry"
         # apiClientId: "registry-client-api"

--- a/docs/modules/ROOT/partials/proc-registry-security-keycloak.adoc
+++ b/docs/modules/ROOT/partials/proc-registry-security-keycloak.adoc
@@ -41,7 +41,7 @@ include::example$/keycloak/keycloak.yaml[]
 
 . Wait until the instance has been created, and click *Networking*  and then *Routes* to access the new route for the *keycloak* instance. 
 
-. Click the *Location* URL and copy the displayed `../auth` URL value for later use when deploying {registry}.
+. Click the *Location* URL and copy the displayed URL value for later use when deploying {registry}.
 
 . Click *Installed Operators* and *{keycloak} Operator*, and click the *Keycloak Realm* tab, and then *Create Keycloak Realm* to create a `registry` example realm:
 +

--- a/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
+++ b/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
@@ -238,27 +238,27 @@ endif::[]
 | `configuration/security/keycloak`
 | -
 | -
-| Web console and REST API security configuration using Keycloak
+| Web console and REST API security configuration using {Keycloak}
 
 | `configuration/security/keycloak/url`
 | string
 | _required_
-| Keycloak URL, must end with `/auth`
+| {keycloak} URL
 
 | `configuration/security/keycloak/realm`
 | string
 | _required_
-| Keycloak realm
+|  {keycloak} realm
 
 | `configuration/security/keycloak/apiClientId`
 | string
 | `registry-client-api`
-| Keycloak client for REST API
+|  {keycloak} client for REST API
 
 | `configuration/security/keycloak/uiClientId`
 | string
 | `registry-client-ui`
-| Keycloak client for web console
+|  {keycloak} client for web console
 
 | `configuration/security/https`
 | -

--- a/docs/modules/ROOT/partials/shared/attributes-links.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes-links.adoc
@@ -1,7 +1,8 @@
 // Upstream
 
 // Downstream
-:LinkRedHatIntegrationDownloads: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=rhboar&downloadType=distributions
+//:LinkRedHatIntegrationDownloads: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=rhboar&downloadType=distributions
+:LinkRedHatIntegrationDownloads: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=red.hat.integration 
 :NameRedHatIntegrationDownloads: Red Hat Software Downloads
 
 :LinkOLMDocs: https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-understanding-olm.html

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -57,6 +57,7 @@ ifdef::RHAF[]
 :prodnamefull: {org-name} Application Foundations
 :registry-name-full: {org-name} build of Apicurio Registry
 :registry: Apicurio Registry
+:operator: {registry} Operator
 endif::[]
 
 endif::[]


### PR DESCRIPTION
Default Keycloak server URL no longer includes `/auth` (see https://github.com/Apicurio/apicurio-registry/issues/3315)

Clean up branding
