### PR TITLE
Update deprecated/unsupported Quarkus Http TLS options

### DIFF
--- a/controllers/cf/cf_https.go
+++ b/controllers/cf/cf_https.go
@@ -177,8 +177,8 @@ func (this *HttpsCF) Sense() {
 	// Observation #5
 	// Find out if Java options is set
 	this.targetJavaOptions = map[string]string{
-		"-Dquarkus.http.ssl.certificate.file":     "/certs/tls.crt",
-		"-Dquarkus.http.ssl.certificate.key-file": "/certs/tls.key",
+		"-Dquarkus.http.ssl.certificate.files":     "/certs/tls.crt",
+		"-Dquarkus.http.ssl.certificate.key-files": "/certs/tls.key",
 	}
 
 	var err error = nil


### PR DESCRIPTION
Fixes #254 

With the Quarkus version upgrade the supporting TLS options also changed.

It no longer uses

quarkus.http.ssl.certificate.key-file quarkus.http.ssl.certificate.file

https://quarkus.io/guides/http-reference#configuring-the-http-server-directly